### PR TITLE
Disable struct hash<QString> declaration Qt versions greater than 5.14

### DIFF
--- a/src/httpServer/util.h
+++ b/src/httpServer/util.h
@@ -211,6 +211,7 @@ struct QStringCaseInSensitiveEqual
 
 namespace std
 {
+    #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     // Default hash and comparator for QString is case-sensitive
     template<> struct hash<QString>
     {
@@ -221,7 +222,7 @@ namespace std
             return qHash(str, seed);
         }
     };
-
+    #endif
     template<> struct equal_to<QString>
     {
         bool operator()(const QString str1, const QString str2) const


### PR DESCRIPTION
If I try to compile with a Qt version greater than 5.14 you get following compile error:  
```c++
httpServer/util.h:216:23: error: redefinition of ‘struct std::hash<QString>’
  216 |     template<> struct hash<QString>
```