### PR TITLE
Fix HttpConnection::~HttpConnection() : crash if socket was connected

### DIFF
--- a/src/httpServer/httpConnection.cpp
+++ b/src/httpServer/httpConnection.cpp
@@ -266,8 +266,9 @@ void HttpConnection::sslErrors(const QList<QSslError> &errors)
 
 HttpConnection::~HttpConnection()
 {
-    delete timeoutTimer;
+    socket->abort();
     delete socket;
+    delete timeoutTimer;
 
     // Delete pending responses
     while (!pendingResponses.empty())


### PR DESCRIPTION
Fixes #8 