### PR TITLE
Fix multipart boundary parsing

### DIFF
--- a/src/httpServer/httpRequest.cpp
+++ b/src/httpServer/httpRequest.cpp
@@ -500,7 +500,7 @@ void HttpRequest::parseContentType()
     }
 
     // Attempt to match syntax for multipart/form-data content type (specifies a boundary instead of a charset)
-    QRegularExpression formDataRegex("^multipart/form-data;\\s*boundary=\"?(.*)\"?$");
+    QRegularExpression formDataRegex("^multipart/form-data;\\s*boundary=\"?([^\"]*)\"?$");
     auto match = formDataRegex.match(contentType);
     if (match.hasMatch())
     {


### PR DESCRIPTION
Before it fails on such Content-Type header value:

```
multipart/form-data; boundary="boundary_.oOo._G0PQMIzO2zsm33XYC/Fd/WMUdjnQ53hr"
```

Parsed boundary was: ```boundary_.oOo._G0PQMIzO2zsm33XYC/Fd/WMUdjnQ53hr"```

This PR fixes regexp for right parsing closing double quote.