### PR TITLE
Added cmake compilation and a file handle http server example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ release/
 *.p12
 
 .vscode
+/build_debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(HttpServer VERSION 1.0.0 LANGUAGES CXX)
+
+find_package(PkgConfig)
+pkg_check_modules(FMT REQUIRED fmt)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+
+FetchContent_Declare(qtpromise
+  GIT_REPOSITORY https://github.com/simonbrunel/qtpromise.git
+  GIT_TAG v0.7.0
+  GIT_SHALLOW true
+)
+
+# CMake v3.14+
+FetchContent_MakeAvailable(qtpromise)
+
+find_package(Qt5 REQUIRED COMPONENTS Core Network)
+
+add_subdirectory(./src)
+add_subdirectory(./test)
+add_subdirectory(./example)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -5,6 +5,9 @@ add_executable(example
   requestHandler.cpp
 )
 
+target_compile_definitions(example PRIVATE
+  "-DROOTDIR=\"${CMAKE_CURRENT_LIST_DIR}/root\"")
+
 target_link_libraries(example PUBLIC
   httpserver
   fmt

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(HTTPSERVER VERSION 1.0.0 LANGUAGES CXX)
+
+add_executable(example
+  main.cpp 
+  requestHandler.cpp
+)
+
+target_link_libraries(example PUBLIC
+  httpserver
+  fmt
+)
+

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,0 +1,25 @@
+#include <QCoreApplication>
+
+#include "httpServer/httpServer.h"
+#include "requestHandler.h"
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
+
+    HttpServerConfig config;
+    config.port = 44388;
+    config.requestTimeout = 20;
+    config.responseTimeout = 5;
+    config.verbosity = HttpServerConfig::Verbose::All;
+    config.maxMultipartSize = 512 * 1024 * 1024;
+    config.errorDocumentMap[HttpStatus::NotFound] = "data/404_2.html";
+    config.errorDocumentMap[HttpStatus::InternalServerError] = "data/404_2.html";
+    config.errorDocumentMap[HttpStatus::BadGateway] = "data/404_2.html";
+
+    RequestHandler *handler = new RequestHandler("/tmp"); // rootdir
+    HttpServer *server = new HttpServer(config, handler);
+    server->listen();
+
+    return a.exec();
+}

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,3 +1,10 @@
+//======================================================================
+//  An example file retrieval http server
+//
+// 2023-10-21 Sat
+// Dov Grobgeld <dov.grobgeld@gmail.com>
+//----------------------------------------------------------------------
+
 #include <QCoreApplication>
 
 #include "httpServer/httpServer.h"
@@ -12,12 +19,8 @@ int main(int argc, char *argv[])
     config.requestTimeout = 20;
     config.responseTimeout = 5;
     config.verbosity = HttpServerConfig::Verbose::All;
-    config.maxMultipartSize = 512 * 1024 * 1024;
-    config.errorDocumentMap[HttpStatus::NotFound] = "data/404_2.html";
-    config.errorDocumentMap[HttpStatus::InternalServerError] = "data/404_2.html";
-    config.errorDocumentMap[HttpStatus::BadGateway] = "data/404_2.html";
 
-    RequestHandler *handler = new RequestHandler("/tmp"); // rootdir
+    RequestHandler *handler = new RequestHandler(ROOTDIR); 
     HttpServer *server = new HttpServer(config, handler);
     server->listen();
 

--- a/example/requestHandler.cpp
+++ b/example/requestHandler.cpp
@@ -1,0 +1,52 @@
+#include "requestHandler.h"
+#include <fmt/core.h>
+
+using fmt::print;
+
+RequestHandler::RequestHandler(const QString& root_dir)
+  : root_dir_(root_dir)
+{
+  router_.addRoute("GET", "^/(.*)$", this, &RequestHandler::handleFile);
+}
+
+HttpPromise RequestHandler::handle(HttpDataPtr data)
+{
+#if 0
+//  data->response->setStatus(HttpStatus::Ok,
+//                            QByteArray("<h1>Lupchi!</h1>stupon"),
+//                            "text/html");
+  data->response->sendFile("/tmp/hello.html", "text/html", "utf-8");
+  data->response->setStatus(HttpStatus::Ok);
+  return HttpPromise::resolve(data);
+#endif
+    bool foundRoute;
+    HttpPromise promise = router_.route(data, &foundRoute);
+    if (foundRoute)
+        return promise;
+    // Return error
+    return promise;
+}
+
+HttpPromise RequestHandler::handleFile(HttpDataPtr data)
+{
+    auto match = data->state["match"].value<QRegularExpressionMatch>();
+    QString filename = match.captured(1);
+
+    QString filepath = root_dir_ + "/" + filename;
+
+    print("Requested to get {}\n", filepath.toStdString());
+
+    if (QFileInfo::exists(filepath))
+    {
+      data->response->sendFile(filepath,
+                               "text/html", "utf-8");
+      data->response->setStatus(HttpStatus::Ok);
+    }
+    else {
+      data->response->setStatus(HttpStatus::NotFound,
+                                QByteArray("File not found!"),
+                                "text/html");
+    }
+
+    return HttpPromise::resolve(data);
+}

--- a/example/requestHandler.h
+++ b/example/requestHandler.h
@@ -18,7 +18,7 @@ private:
     QString root_dir_;
 
 public:
-    RequestHandler(const QString& root_dir = "/tmp");
+    RequestHandler(const QString& root_dir);
 
     HttpPromise handle(HttpDataPtr data) override;
     HttpPromise handleFile(HttpDataPtr data);

--- a/example/requestHandler.h
+++ b/example/requestHandler.h
@@ -1,0 +1,27 @@
+#ifndef REQUESTHANDLER_H
+#define REQUESTHANDLER_H
+
+#include <QtPromise>
+#include <QTimer>
+
+#include "httpServer/httpData.h"
+#include "httpServer/httpRequestHandler.h"
+#include "httpServer/httpRequestRouter.h"
+
+
+using QtPromise::QPromise;
+
+class RequestHandler : public HttpRequestHandler
+{
+private:
+    HttpRequestRouter router_;
+    QString root_dir_;
+
+public:
+    RequestHandler(const QString& root_dir = "/tmp");
+
+    HttpPromise handle(HttpDataPtr data) override;
+    HttpPromise handleFile(HttpDataPtr data);
+};
+
+#endif // REQUESTHANDLER_H

--- a/example/root/index.html
+++ b/example/root/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <title></title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <h1>Hello world!</h1>
+    How do we reboot it and try again?
+  </body>
+</html>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,29 @@
+project(HTTPSERVER VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+
+add_library(httpserver
+  httpServer/httpConnection.cpp 
+  httpServer/httpData.cpp 
+  httpServer/httpRequest.cpp 
+  httpServer/httpRequestRouter.cpp 
+  httpServer/httpResponse.cpp 
+  httpServer/httpServer.cpp 
+  httpServer/httpRequestHandler.h
+  httpServer/middleware/CORS.cpp 
+  httpServer/middleware/auth.cpp 
+  httpServer/middleware/getArray.cpp 
+  httpServer/middleware/getObject.cpp 
+  httpServer/middleware/verifyJson.cpp 
+  httpServer/util.cpp
+)
+
+target_link_libraries(httpserver PUBLIC
+  Qt5::Core
+  Qt5::Network
+  qtpromise
+  z
+)
+
+target_include_directories(httpserver PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/httpServer/httpCookie.h
+++ b/src/httpServer/httpCookie.h
@@ -34,13 +34,13 @@ struct HTTPSERVER_EXPORT HttpCookie
         buf += QUrl::toPercentEncoding(value);
 
         if (expiration.isValid())
-            buf += "; Expires=" + expiration.toString(Qt::RFC2822Date);
+            buf += "; Expires=" + expiration.toString(Qt::RFC2822Date).toUtf8();
 
         if (ageSeconds > 0)
-            buf += "; Max-Age=" + QString::number(ageSeconds);
+            buf += "; Max-Age=" + QString::number(ageSeconds).toUtf8();
 
         if (!domain.isEmpty())
-            buf += "; Domain=" + domain;
+            buf += "; Domain=" + domain.toUtf8();
 
         if (!path.isEmpty())
             buf += "; Path=" + QUrl::toPercentEncoding(path);

--- a/src/httpServer/httpResponse.cpp
+++ b/src/httpServer/httpResponse.cpp
@@ -258,19 +258,19 @@ void HttpResponse::prepareToSend()
     buffer.reserve(2048 + body_.length());
 
     // Status line
-    buffer += version_;
+    buffer += version_.toUtf8();
     buffer += ' ';
-    buffer += QString::number((int)status_);
+    buffer += QString::number((int)status_).toUtf8();
     buffer += ' ';
-    buffer += getHttpStatusStr(status_);
+    buffer += getHttpStatusStr(status_).toUtf8();
     buffer += "\r\n";
 
     // Headers
     for (auto &keyValue : headers)
     {
-        buffer += keyValue.first;
+        buffer += keyValue.first.toUtf8();
         buffer += ": ";
-        buffer += keyValue.second;
+        buffer += keyValue.second.toUtf8();
         buffer += "\r\n";
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(HTTPSERVER VERSION 1.0.0 LANGUAGES CXX)
+
+add_executable(test-http-server
+  main.cpp 
+  requestHandler.cpp
+)
+
+target_link_libraries(test-http-server PUBLIC
+  httpserver
+)
+


### PR DESCRIPTION
Thanks for the simple and featurefull http server! It works great under Qt5.

This pull request contains the following features:

- Added cmake based compilation files
- Added a pure file handler http server example in the example directory
- Fixed compilation errors for deprecated casting from QString() to QByteArray()

Please let me know if this is of interest, and whether you prefer that I separate these three issues into separate pull requests.

